### PR TITLE
Add use-db recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+## nixels
+
+This is a collection of nix-shell recipes organized under a top-level
+[default.nix](default.nix) expression. It's structured so recipes can be
+referenced by attribute name:
+```sh
+nix-shell --attr use-db \
+    https://github.com/ivanbrennan/nixels/archive/master.tar.gz
+```
+
+Recipes are versioned and git tags of the form `<recipe>-<version>` are
+provided, allowing you to reference a particular version:
+```sh
+nix-shell --attr use-db \
+    https://github.com/ivanbrennan/nixels/archive/use-db-0.1.0.tar.gz
+```
+
+I've also written a CLI,
+[shellbit](https://github.com/ivanbrennan/shellbit#shellbit), to make
+referencing recipe collections like this one less cumbersome:
+```sh
+$ cd /path/to/projects/use-db
+$ shellbit
+[nix-shell:~/Development/use-db]$
+```

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+{
+  use-db = pkgs.callPackage ./use-db { };
+}

--- a/use-db/db-client
+++ b/use-db/db-client
@@ -1,0 +1,71 @@
+#! /usr/bin/env bash
+
+set -eu
+
+pids_dir="$PWD/nix/pids/db-client"
+log_dir="$PWD/nix/log"
+
+add_client() {
+    mkdir -p "$pids_dir" && touch "$pids_dir/$PPID"
+    add_postgres
+}
+
+add_postgres() {
+    # Spin up a postgres server iff PGHOST is a Unix-domain socket.
+    # Otherwise, assume the host is already up and running.
+    [ "${PGHOST:0:1}" = "/" ] || return 0
+
+    if [ -d "$PGDATA" ]
+    then
+        start_postgres
+    else
+        pg_ctl initdb --silent -o '--auth=trust'
+        start_postgres && createdb $PGDATABASE
+    fi
+}
+
+start_postgres() {
+    if postgres_is_stopped
+    then
+        # We'll use a Unix-domain socket we control, and avoid listening for
+        # TCP connections. This prevents conflicts with any other postgres
+        # server the host is running, even if it's listening on the same port.
+        local logfile="${log_dir}/pg.log"
+        mkdir -p "$PGHOST" "${logfile%/*}"
+        (set -m
+        pg_ctl start --silent -w --log "$logfile" -o "-k $PGHOST -h ''")
+    fi
+}
+
+postgres_is_stopped() {
+    pg_isready --quiet
+    (( $? == 2 ))
+}
+
+remove_client() {
+    rm "$pids_dir/$PPID"
+
+    if [ -n "$(find "$pids_dir" -prune -empty)" ]
+    then
+        stop_postgres
+    fi
+}
+
+stop_postgres() {
+    # Shut down the postgres server iff PGHOST is a Unix-domain socket.
+    # Otherwise, it's being managed by some other host/process.
+    [ "${PGHOST:0:1}" = "/" ] || return 0
+
+    pg_isready --quiet || return 0
+    pg_ctl stop --silent -W -m smart
+}
+
+case "$1" in
+    add)
+        add_client ;;
+    remove)
+        remove_client ;;
+    *)
+        echo "Usage: ${BASH_SOURCE[0]##*/} {add | remove}"
+        exit 1 ;;
+esac

--- a/use-db/db-client.nix
+++ b/use-db/db-client.nix
@@ -1,0 +1,32 @@
+{ bash
+, findutils
+, lib
+, makeWrapper
+, postgresql
+, runCommand
+, stdenv
+}:
+
+let
+  propagatedBuildInputs = [
+    bash
+    findutils
+    postgresql
+  ];
+
+in runCommand "db-client" {
+  inherit propagatedBuildInputs;
+  nativeBuildInputs = [ makeWrapper ];
+} ''
+  install -D -m755 ${./db-client} $out/bin/$name
+  patchShebangs --host $out/bin
+
+  ${stdenv.shell} -n $out/bin/$name
+
+  wrapProgram $out/bin/$name \
+      --prefix PATH : "${lib.makeBinPath propagatedBuildInputs}"
+
+  mkdir -p $out/nix-support
+  printWords ${toString propagatedBuildInputs} \
+      > $out/nix-support/propagated-build-inputs
+''

--- a/use-db/db.env
+++ b/use-db/db.env
@@ -1,0 +1,5 @@
+export PGDATABASE="${PGDATABASE:-use-db}" \
+       PGDATA="${PGDATA:-$PWD/nix/pgdata}" \
+       PGHOST="${PGHOST:-$PWD/nix/sockets}" \
+       PGPORT="${PGPORT:-5433}" \
+       PGUSER="${PGUSER:-$USER}"

--- a/use-db/default.nix
+++ b/use-db/default.nix
@@ -1,0 +1,28 @@
+{ pkgs }:
+
+with pkgs;
+
+let
+  db-env = copyPathToStore ./db.env;
+  db-client = callPackage ./db-client.nix { };
+
+in mkShell {
+  pname = "use-db";
+  version = "0.1.0";
+
+  buildInputs = [
+    glibcLocales
+    postgresql
+  ];
+
+  shellHook = ''
+    set -e
+
+    export LANG=en_US.UTF-8
+    . ${db-env}
+    trap "'${db-client}/bin/db-client' remove" EXIT
+    '${db-client}/bin/db-client' add
+
+    set +e
+  '';
+}


### PR DESCRIPTION
This recipe demonstrates how to:
- use `copyPathToStore` to access flat files from the shell
- spin up postgres upon entering the shell
- tear down postgres upon leaving the shell