### PR TITLE
Add use-queue recipe

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,8 @@
 { pkgs ? import <nixpkgs> { } }:
 
+with pkgs;
+
 {
-  use-db = pkgs.callPackage ./use-db { };
+  use-db = callPackage ./use-db { };
+  use-queue = callPackage ./use-queue { };
 }

--- a/use-queue/aliases
+++ b/use-queue/aliases
@@ -1,0 +1,1 @@
+alias redis-cli='redis-cli -p $REDIS_PORT'

--- a/use-queue/default.nix
+++ b/use-queue/default.nix
@@ -1,0 +1,28 @@
+{ pkgs }:
+
+with pkgs;
+
+let
+  aliases = copyPathToStore ./aliases;
+  queue-env = copyPathToStore ./queue.env;
+  queue-client = callPackage ./queue-client.nix { };
+
+in mkShell {
+  pname = "use-queue";
+  version = "0.1.0";
+
+  buildInputs = [
+    redis
+  ];
+
+  shellHook = ''
+    set -e
+
+    . ${aliases}
+    . ${queue-env}
+    trap "'${queue-client}/bin/queue-client' remove" EXIT
+    '${queue-client}/bin/queue-client' add
+
+    set +e
+  '';
+}

--- a/use-queue/queue-client
+++ b/use-queue/queue-client
@@ -1,0 +1,59 @@
+#! /usr/bin/env bash
+
+set -eu
+
+pids_dir="$PWD/nix/pids/queue-client"
+
+add_client() {
+    mkdir -p "$pids_dir" && touch "$pids_dir/$PPID"
+    add_redis
+}
+
+add_redis() {
+    local \
+        data_dir="$PWD/nix/redis/$REDIS_PORT/" \
+        logfile="$PWD/log/redis_$REDIS_PORT.log" \
+        pidfile="$PWD/tmp/pids/redis_$REDIS_PORT.pid"
+
+    mkdir -p \
+        "$data_dir" \
+        "${logfile%/*}" \
+        "${pidfile%/*}"
+
+    if redis_is_stopped
+    then
+        redis-server --daemonize yes \
+                     --port $REDIS_PORT \
+                     --dir "$data_dir" \
+                     --logfile "$logfile" \
+                     --pidfile "$pidfile"
+    fi
+}
+
+redis_is_stopped() {
+    ! redis-cli -p $REDIS_PORT ping
+} >/dev/null 2>&1
+
+remove_client() {
+    rm "$pids_dir/$PPID"
+
+    if [ -n "$(find "$pids_dir" -prune -empty)" ]
+    then
+        stop_redis
+    fi
+}
+
+stop_redis() {
+    redis-cli -p $REDIS_PORT save >/dev/null
+    redis-cli -p $REDIS_PORT shutdown
+}
+
+case "$1" in
+    add)
+        add_client ;;
+    remove)
+        remove_client ;;
+    *)
+        echo "Usage: ${BASH_SOURCE[0]##*/} {add | remove}"
+        exit 1 ;;
+esac

--- a/use-queue/queue-client.nix
+++ b/use-queue/queue-client.nix
@@ -1,0 +1,32 @@
+{ bash
+, findutils
+, lib
+, makeWrapper
+, redis
+, runCommand
+, stdenv
+}:
+
+let
+  propagatedBuildInputs = [
+    bash
+    findutils
+    redis
+  ];
+
+in runCommand "queue-client" {
+  inherit propagatedBuildInputs;
+  nativeBuildInputs = [ makeWrapper ];
+} ''
+  install -D -m755 ${./queue-client} $out/bin/$name
+  patchShebangs --host $out/bin
+
+  ${stdenv.shell} -n $out/bin/$name
+
+  wrapProgram $out/bin/$name \
+      --prefix PATH : "${lib.makeBinPath propagatedBuildInputs}"
+
+  mkdir -p $out/nix-support
+  printWords ${toString propagatedBuildInputs} \
+      > $out/nix-support/propagated-build-inputs
+''

--- a/use-queue/queue.env
+++ b/use-queue/queue.env
@@ -1,0 +1,1 @@
+export REDIS_PORT="${REDIS_PORT:-6380}"


### PR DESCRIPTION
This recipe demonstrates how to:
- spin up redis upon entering the shell
- tear down redis upon leaving the shell
- use aliases to make non-standard ports less cumbersome